### PR TITLE
Add update board functionality with API integration and optimistic UI updates

### DIFF
--- a/src/lib/redux/store.ts
+++ b/src/lib/redux/store.ts
@@ -5,6 +5,7 @@ import rootReducer from '~/store/root.reducer'
 // Configure Redux-Persist
 import storage from 'redux-persist/lib/storage'
 import { persistReducer, persistStore } from 'redux-persist'
+
 import { boardApi } from '~/queries/boards'
 import { columnApi } from '~/queries/columns'
 import { cardApi } from '~/queries/cards'

--- a/src/queries/boards.ts
+++ b/src/queries/boards.ts
@@ -1,7 +1,9 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
 import { isEmpty } from 'lodash'
+import { toast } from 'react-toastify'
 import axiosBaseQuery from '~/lib/redux/helpers'
-import { BoardResType } from '~/schemas/board.schema'
+import { BoardResType, UpdateBoardBodyType } from '~/schemas/board.schema'
+import { ColumnType } from '~/schemas/column.schema'
 import { generatePlaceholderCard } from '~/utils/utils'
 
 const BOARD_API_URL = '/boards' as const
@@ -47,11 +49,45 @@ export const boardApi = createApi({
       },
       providesTags: (result, _error, id) =>
         result ? [{ type: 'Board', id: result.result._id }] : [{ type: 'Board', id }]
+    }),
+
+    updateBoard: build.mutation<
+      BoardResType,
+      { id: string; dndOrderedColumns: ColumnType[]; body: UpdateBoardBodyType }
+    >({
+      query: ({ id, body }) => ({ url: `${BOARD_API_URL}/${id}`, method: 'PUT', data: body }),
+      async onQueryStarted({ id, dndOrderedColumns, body }, { dispatch, queryFulfilled }) {
+        const updateBoardResult = dispatch(
+          boardApi.util.updateQueryData('getBoard', id, (draft) => {
+            if (draft?.result) {
+              const dndOrderedColumnsIds = dndOrderedColumns.map((column) => column._id)
+
+              // Updating the board's columns and card order IDs in the cache
+              // These take precedence over any column data in body
+              draft.result.columns = dndOrderedColumns
+              draft.result.column_order_ids = dndOrderedColumnsIds
+
+              // Update all board properties from the bodyUpdate
+              Object.assign(draft.result, body)
+            }
+          })
+        )
+
+        try {
+          await queryFulfilled
+        } catch (error) {
+          // Rollback the optimistic update if the query fails
+          updateBoardResult.undo()
+
+          toast.error('There was an error updating the board')
+          console.error(error)
+        }
+      }
     })
   })
 })
 
-export const { useGetBoardQuery } = boardApi
+export const { useGetBoardQuery, useUpdateBoardMutation } = boardApi
 
 const boardApiReducer = boardApi.reducer
 

--- a/src/schemas/board.schema.ts
+++ b/src/schemas/board.schema.ts
@@ -44,3 +44,19 @@ export const CreateBoardBody = z.object({
 })
 
 export type CreateBoardBodyType = z.TypeOf<typeof CreateBoardBody>
+
+export const UpdateBoardBody = z.object({
+  title: z
+    .string()
+    .min(3, { message: 'Title must be at least 3 characters long' })
+    .max(50, { message: 'Title must be at most 50 characters long' }),
+  description: z
+    .string()
+    .min(3, { message: 'Description must be at least 3 characters long' })
+    .max(256, { message: 'Description must be at most 256 characters long' })
+    .optional(),
+  type: z.enum(BoardTypeValues, { message: 'Type must be either public or private' }).default(BoardType.Public),
+  column_order_ids: z.array(z.string())
+})
+
+export type UpdateBoardBodyType = z.TypeOf<typeof UpdateBoardBody>


### PR DESCRIPTION
Implement an update feature for boards that integrates with the API and provides optimistic UI updates. This allows for a smoother user experience when reordering columns and updating board details.