### PR TITLE
Refactor board state management and API fetching

### DIFF
--- a/src/pages/Boards/BoardDetails/components/BoardContent/BoardContent.tsx
+++ b/src/pages/Boards/BoardDetails/components/BoardContent/BoardContent.tsx
@@ -1,6 +1,5 @@
 import {
   Active,
-  closestCenter,
   closestCorners,
   defaultDropAnimationSideEffects,
   DndContext,
@@ -24,8 +23,6 @@ import { MouseSensor, TouchSensor } from '~/lib/dnd-kit'
 import Card from '~/pages/Boards/BoardDetails/components/Card'
 import Column from '~/pages/Boards/BoardDetails/components/Column'
 import ColumnsList from '~/pages/Boards/BoardDetails/components/ColumnsList'
-import { useUpdateBoardMutation } from '~/queries/boards'
-import { useUpdateColumnMutation } from '~/queries/columns'
 import { BoardResType } from '~/schemas/board.schema'
 import { CardType } from '~/schemas/card.schema'
 import { ColumnType } from '~/schemas/column.schema'
@@ -33,6 +30,8 @@ import { generatePlaceholderCard } from '~/utils/utils'
 
 interface BoardContentProps {
   board: BoardResType['result']
+  onMoveColumns: (dndOrderedColumns: ColumnType[]) => void
+  onMoveCardInTheSameColumn: (dndOrderedCards: CardType[], dndOrderedCardsIds: string[], columnId: string) => void
 }
 
 const ACTIVE_DRAG_ITEM_TYPE = {
@@ -40,7 +39,7 @@ const ACTIVE_DRAG_ITEM_TYPE = {
   CARD: 'ACTIVE_DRAG_ITEM_TYPE_CARD'
 }
 
-export default function BoardContent({ board }: BoardContentProps) {
+export default function BoardContent({ board, onMoveColumns, onMoveCardInTheSameColumn }: BoardContentProps) {
   const mouseSensor = useSensor(MouseSensor, {
     activationConstraint: { distance: 10 }
   })
@@ -51,6 +50,7 @@ export default function BoardContent({ board }: BoardContentProps) {
   const sensors = useSensors(mouseSensor, touchSensor)
 
   const [sortedColumns, setSortedColumns] = useState<ColumnType[]>([])
+
   const [activeDragItemId, setActiveDragItemId] = useState<UniqueIdentifier | null>(null)
   const [activeDragItemType, setActiveDragItemType] = useState<string | null>(null)
   const [activeDragItemData, setActiveDragItemData] = useState<any | null>(null)
@@ -58,42 +58,12 @@ export default function BoardContent({ board }: BoardContentProps) {
 
   const lastOverId = useRef<UniqueIdentifier | null>(null)
 
-  const [updateBoardMutation] = useUpdateBoardMutation()
-  const [updateColumnMutation] = useUpdateColumnMutation()
-
   useEffect(() => {
     setSortedColumns(board.columns!)
   }, [board])
 
   const findColumnByCardId = (cardId: UniqueIdentifier) => {
-    return sortedColumns.find((column) => column?.cards?.map((card) => card._id).includes(cardId as string))
-  }
-
-  const moveColumns = async (dndOrderedColumns: ColumnType[]) => {
-    const boardColumnOrderIds = dndOrderedColumns.map((column) => column._id)
-
-    await updateBoardMutation({
-      id: board._id,
-      body: {
-        column_order_ids: boardColumnOrderIds,
-        dnd_ordered_columns: dndOrderedColumns
-      }
-    })
-  }
-
-  const moveCardInTheSameColumn = async (
-    dndOrderedCards: CardType[],
-    dndOrderedCardsIds: string[],
-    columnId: string
-  ) => {
-    await updateColumnMutation({
-      id: columnId,
-      body: {
-        card_order_ids: dndOrderedCardsIds,
-        board_id: board._id,
-        dnd_ordered_cards: dndOrderedCards
-      }
-    })
+    return sortedColumns.find((column) => column?.cards?.map((card) => card._id)?.includes(cardId as string))
   }
 
   const moveCardBetweenDifferentColumns = ({
@@ -114,7 +84,7 @@ export default function BoardContent({ board }: BoardContentProps) {
     activeDraggingCardData: CardType
   }) => {
     setSortedColumns((prevColumns) => {
-      const overCardIndex = overColumn?.cards?.findIndex((card) => card._id === overCardId) ?? -1
+      const overCardIndex = overColumn?.cards?.findIndex((card) => card._id === overCardId) as number
 
       let newCardIndex: number
       const isBelowOverItem =
@@ -156,14 +126,14 @@ export default function BoardContent({ board }: BoardContentProps) {
   }
 
   const handleDragStart = (event: DragStartEvent) => {
-    const { active } = event
+    setActiveDragItemId(event?.active?.id as string)
+    setActiveDragItemType(
+      event?.active?.data?.current?.column_id ? ACTIVE_DRAG_ITEM_TYPE.CARD : ACTIVE_DRAG_ITEM_TYPE.COLUMN
+    )
+    setActiveDragItemData(event?.active?.data?.current)
 
-    setActiveDragItemId(active?.id as string)
-    setActiveDragItemType(active?.data?.current?.column_id ? ACTIVE_DRAG_ITEM_TYPE.CARD : ACTIVE_DRAG_ITEM_TYPE.COLUMN)
-    setActiveDragItemData(active?.data?.current)
-
-    if (active?.data?.current?.column_id) {
-      const column = findColumnByCardId(active?.id) as ColumnType
+    if (event?.active?.data?.current?.column_id) {
+      const column = findColumnByCardId(event?.active?.id)!
       setOldColumnWhenDraggingCard(column)
     }
   }
@@ -226,7 +196,7 @@ export default function BoardContent({ board }: BoardContentProps) {
         return
       }
 
-      if (oldColumnWhenDraggingCard && oldColumnWhenDraggingCard._id !== overColumn._id) {
+      if (oldColumnWhenDraggingCard?._id !== overColumn._id) {
         moveCardBetweenDifferentColumns({
           overColumn,
           overCardId,
@@ -237,26 +207,30 @@ export default function BoardContent({ board }: BoardContentProps) {
           activeDraggingCardData: activeDraggingCardData as CardType
         })
       } else {
-        const oldCardIndex =
-          oldColumnWhenDraggingCard?.cards?.findIndex((card) => card._id === activeDraggingCardId) ?? -1
-        const newCardIndex = overColumn?.cards?.findIndex((card) => card._id === overCardId) ?? -1
-        const oldColumnCards = oldColumnWhenDraggingCard?.cards ?? []
+        const oldCardIndex = oldColumnWhenDraggingCard?.cards?.findIndex(
+          (card) => card._id === activeDraggingCardId
+        ) as number
+        const newCardIndex = overColumn?.cards?.findIndex((card) => card._id === overCardId) as number
+
+        const oldColumnCards = oldColumnWhenDraggingCard?.cards as CardType[]
 
         const dndOrderedCards = arrayMove(oldColumnCards, oldCardIndex, newCardIndex)
         const dndOrderedCardsIds = dndOrderedCards.map((card) => card._id)
 
-        setSortedColumns((prevColumns) => {
-          const nextColumns = cloneDeep(prevColumns)
+        if (oldCardIndex !== newCardIndex) {
+          setSortedColumns((prevColumns) => {
+            const nextColumns = cloneDeep(prevColumns)
 
-          const targetColumn = nextColumns.find((column) => column._id === overColumn._id) as ColumnType
+            const targetColumn = nextColumns.find((column) => column._id === overColumn._id)!
 
-          targetColumn.cards = dndOrderedCards
-          targetColumn.card_order_ids = dndOrderedCardsIds
+            targetColumn.cards = dndOrderedCards
+            targetColumn.card_order_ids = dndOrderedCardsIds
 
-          return nextColumns
-        })
+            return nextColumns
+          })
 
-        moveCardInTheSameColumn(dndOrderedCards, dndOrderedCardsIds, (oldColumnWhenDraggingCard as ColumnType)._id)
+          onMoveCardInTheSameColumn(dndOrderedCards, dndOrderedCardsIds, (oldColumnWhenDraggingCard as ColumnType)._id)
+        }
       }
     }
 
@@ -269,7 +243,7 @@ export default function BoardContent({ board }: BoardContentProps) {
 
         setSortedColumns(dndOrderedColumns)
 
-        moveColumns(dndOrderedColumns)
+        onMoveColumns(dndOrderedColumns)
       }
     }
 
@@ -304,7 +278,7 @@ export default function BoardContent({ board }: BoardContentProps) {
 
         if (checkColumn) {
           // Can use `closestCenter` or `closestCorners` here
-          overId = closestCenter({
+          overId = closestCorners({
             ...args,
             droppableContainers: args.droppableContainers.filter((container: DroppableContainer) => {
               return container.id !== overId && checkColumn?.card_order_ids?.includes(container.id as string)
@@ -340,7 +314,7 @@ export default function BoardContent({ board }: BoardContentProps) {
           })
         }}
       >
-        <ColumnsList boardId={board._id} columns={sortedColumns} />
+        <ColumnsList columns={sortedColumns} />
         <DragOverlay dropAnimation={customDropAnimation}>
           {!activeDragItemType && null}
           {activeDragItemType === ACTIVE_DRAG_ITEM_TYPE.COLUMN && <Column column={activeDragItemData} />}

--- a/src/queries/boards.ts
+++ b/src/queries/boards.ts
@@ -1,11 +1,7 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
-import { isEmpty } from 'lodash'
 import { toast } from 'react-toastify'
 import axiosBaseQuery from '~/lib/redux/helpers'
 import { BoardResType, UpdateBoardBodyType } from '~/schemas/board.schema'
-import { ColumnType } from '~/schemas/column.schema'
-import { mapOrder } from '~/utils/sorts'
-import { generatePlaceholderCard } from '~/utils/utils'
 
 const BOARD_API_URL = '/boards' as const
 
@@ -17,86 +13,18 @@ export const boardApi = createApi({
   tagTypes,
   baseQuery: axiosBaseQuery(),
   endpoints: (build) => ({
-    getBoard: build.query<BoardResType, string>({
-      query: (id) => ({ url: `${BOARD_API_URL}/${id}`, method: 'GET' }),
-      // Should use `transformResponse` to create a new transformed object.
-      transformResponse: (response: BoardResType) => {
-        // RTK Query freezes response data to prevent mutations, which is causing the error.
-
-        // So creating a shadow copy of the response to avoid mutating the original object
-        const boardRes = { ...response }
-
-        if (boardRes.result?.columns) {
-          // columns according to column_order_ids before further processing
-          const sortedColumns = mapOrder(boardRes.result.columns, boardRes.result.column_order_ids, '_id')
-
-          // Creating a new result object with updated columns - proper immutable approach
-          boardRes.result = {
-            ...boardRes.result,
-
-            // Using map to create new column objects rather than modifying in-place
-            columns: sortedColumns.map((column) => {
-              if (isEmpty(column.cards)) {
-                const placeholderCard = generatePlaceholderCard(column)
-                // Creating a new column with the placeholder card - correctly avoiding mutations
-                return {
-                  ...column,
-                  cards: [placeholderCard],
-                  card_order_ids: [placeholderCard._id]
-                }
-              } else {
-                // If cards are not empty, sort them according to card_order_ids
-                const sortedCards = mapOrder(column.cards, column.card_order_ids, '_id')
-
-                return { ...column, cards: sortedCards }
-              }
-            })
-          }
-        }
-
-        return boardRes
-      },
-      providesTags: (result, _error, id) =>
-        result ? [{ type: 'Board', id: result.result._id }] : [{ type: 'Board', id }]
-    }),
-
     updateBoard: build.mutation<
       BoardResType,
       {
         id: string
-        body: UpdateBoardBodyType & { dnd_ordered_columns?: ColumnType[] }
+        body: UpdateBoardBodyType
       }
     >({
       query: ({ id, body }) => ({ url: `${BOARD_API_URL}/${id}`, method: 'PUT', data: body }),
-      async onQueryStarted({ id, body }, { dispatch, queryFulfilled }) {
-        const updateBoardResult = dispatch(
-          boardApi.util.updateQueryData('getBoard', id, (draft) => {
-            if (draft.result) {
-              const dndOrderedColumns = body.dnd_ordered_columns
-              const dndOrderedColumnsIds = body.column_order_ids
-
-              // Updating the board's columns and card order IDs in the cache
-              // These take precedence over any column data in body
-              if (dndOrderedColumns) {
-                draft.result.columns = dndOrderedColumns
-              }
-
-              if (dndOrderedColumnsIds) {
-                draft.result.column_order_ids = dndOrderedColumnsIds
-              }
-
-              // Update all board properties from the bodyUpdate
-              Object.assign(draft.result, body)
-            }
-          })
-        )
-
+      async onQueryStarted(_args, { queryFulfilled }) {
         try {
           await queryFulfilled
         } catch (error) {
-          // Rollback the optimistic update if the query fails
-          updateBoardResult.undo()
-
           toast.error('There was an error updating the board')
           console.error(error)
         }
@@ -105,7 +33,7 @@ export const boardApi = createApi({
   })
 })
 
-export const { useGetBoardQuery, useUpdateBoardMutation } = boardApi
+export const { useUpdateBoardMutation } = boardApi
 
 const boardApiReducer = boardApi.reducer
 

--- a/src/queries/cards.ts
+++ b/src/queries/cards.ts
@@ -1,7 +1,6 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
 import { toast } from 'react-toastify'
 import axiosBaseQuery from '~/lib/redux/helpers'
-import { boardApi } from '~/queries/boards'
 import { CardResType, CreateCardBodyType } from '~/schemas/card.schema'
 
 const CARD_API_URL = '/cards' as const
@@ -16,35 +15,10 @@ export const cardApi = createApi({
   endpoints: (build) => ({
     addCard: build.mutation<CardResType, CreateCardBodyType>({
       query: (body) => ({ url: CARD_API_URL, method: 'POST', data: body }),
-      async onQueryStarted({ board_id }, { dispatch, queryFulfilled }) {
+      async onQueryStarted(_args, { queryFulfilled }) {
         try {
           const { data } = await queryFulfilled
           toast.success(data.message || 'Card added successfully')
-
-          // Optimistically update the board's columns and cards in the cache
-          dispatch(
-            boardApi.util.updateQueryData('getBoard', board_id, (draft) => {
-              if (draft.result) {
-                const newCard = data.result
-                const columnToUpdate = draft.result.columns?.find((column) => column._id === newCard.column_id)
-
-                // If the column exists, add the new card to it
-                if (columnToUpdate) {
-                  if (!columnToUpdate.cards) {
-                    columnToUpdate.cards = []
-                  }
-
-                  // Add the new card to the column's cards
-                  columnToUpdate.cards.push(newCard)
-
-                  // Update card_order_ids if it exists
-                  if (columnToUpdate.card_order_ids) {
-                    columnToUpdate.card_order_ids.push(newCard._id)
-                  }
-                }
-              }
-            })
-          )
         } catch (error) {
           toast.error('There was an error adding the card')
           console.error(error)

--- a/src/queries/columns.ts
+++ b/src/queries/columns.ts
@@ -1,10 +1,7 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
 import { toast } from 'react-toastify'
 import axiosBaseQuery from '~/lib/redux/helpers'
-import { boardApi } from '~/queries/boards'
-import { CardType } from '~/schemas/card.schema'
 import { ColumnResType, CreateColumnBodyType, UpdateColumnBodyType } from '~/schemas/column.schema'
-import { generatePlaceholderCard } from '~/utils/utils'
 
 const COLUMN_API_URL = '/columns' as const
 
@@ -19,95 +16,23 @@ export const columnApi = createApi({
   endpoints: (build) => ({
     addColumn: build.mutation<ColumnResType, CreateColumnBodyType>({
       query: (body) => ({ url: COLUMN_API_URL, method: 'POST', data: body }),
-      transformResponse: (response: ColumnResType) => {
-        const columnRes = { ...response }
-        const placeholderCard = generatePlaceholderCard(columnRes.result)
-
-        columnRes.result = {
-          ...columnRes.result,
-          cards: [placeholderCard],
-          card_order_ids: [placeholderCard._id]
-        }
-
-        return columnRes
-      },
-      async onQueryStarted({ board_id }, { dispatch, queryFulfilled }) {
+      async onQueryStarted(_args, { queryFulfilled }) {
         try {
           const { data } = await queryFulfilled
           toast.success(data.message || 'Column added successfully')
-
-          // Optimistically update the board's columns in the cache
-          dispatch(
-            boardApi.util.updateQueryData('getBoard', board_id, (draft) => {
-              // If draft exists and has columns property, update it with the new column
-              if (draft.result) {
-                const newColumn = data.result
-
-                // Add the new column to the board's columns
-                if (!draft.result.columns) {
-                  draft.result.columns = []
-                }
-
-                draft.result.columns.push(newColumn)
-
-                // Update column_order_ids if it exists
-                if (draft.result.column_order_ids) {
-                  draft.result.column_order_ids.push(newColumn._id)
-                }
-              }
-            })
-          )
-
-          // Invalidate the board cache to ensure the latest data is fetched
-          // This will cause the page to reload when the column is successfully added - bad UX
-          // dispatch(boardApi.util.invalidateTags([{ type: 'Board', id: board_id }]))
         } catch (error) {
           toast.error('There was an error adding the column')
           console.error(error)
         }
-      },
-      invalidatesTags: [{ type: 'Column', id: 'LIST' }]
+      }
     }),
 
-    updateColumn: build.mutation<
-      ColumnResType,
-      {
-        id: string
-        body: UpdateColumnBodyType & { board_id: string; dnd_ordered_cards?: CardType[] }
-      }
-    >({
+    updateColumn: build.mutation<ColumnResType, { id: string; body: UpdateColumnBodyType }>({
       query: ({ id, body }) => ({ url: `${COLUMN_API_URL}/${id}`, method: 'PUT', data: body }),
-      async onQueryStarted({ id, body }, { dispatch, queryFulfilled }) {
-        const { board_id } = body
-
-        const updateColumnResult = dispatch(
-          boardApi.util.updateQueryData('getBoard', board_id, (draft) => {
-            if (draft.result) {
-              const columnToUpdate = draft.result.columns?.find((column) => column._id === id)
-              const dndOrderedCards = body.dnd_ordered_cards
-              const dndOrderedCardsIds = body.card_order_ids
-
-              if (columnToUpdate) {
-                if (dndOrderedCards) {
-                  columnToUpdate.cards = dndOrderedCards
-                }
-
-                if (dndOrderedCardsIds) {
-                  columnToUpdate.card_order_ids = dndOrderedCardsIds
-                }
-
-                Object.assign(columnToUpdate, body)
-              }
-            }
-          })
-        )
-
+      async onQueryStarted(_args, { queryFulfilled }) {
         try {
           await queryFulfilled
         } catch (error) {
-          // Rollback the optimistic update if the query fails
-          updateColumnResult.undo()
-
           toast.error('There was an error updating the column')
           console.error(error)
         }

--- a/src/store/root.reducer.ts
+++ b/src/store/root.reducer.ts
@@ -3,9 +3,11 @@ import boardApiReducer, { boardApi } from '~/queries/boards'
 import cardApiReducer, { cardApi } from '~/queries/cards'
 import columnApiReducer, { columnApi } from '~/queries/columns'
 import appReducer from '~/store/slices/app.slice'
+import boardReducer from '~/store/slices/board.slice'
 
 const rootReducer = combineReducers({
   app: appReducer,
+  board: boardReducer,
 
   [boardApi.reducerPath]: boardApiReducer,
 

--- a/src/store/slices/board.slice.ts
+++ b/src/store/slices/board.slice.ts
@@ -1,0 +1,82 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { isEmpty } from 'lodash'
+import { envConfig } from '~/constants/config'
+import http from '~/lib/http'
+import { BoardResType } from '~/schemas/board.schema'
+import { mapOrder } from '~/utils/sorts'
+import { generatePlaceholderCard } from '~/utils/utils'
+
+interface BoardSliceState {
+  activeBoard: BoardResType['result'] | null
+  loading: string
+  currentRequestId: string | undefined
+}
+
+const initialState: BoardSliceState = {
+  activeBoard: null,
+  loading: 'idle',
+  currentRequestId: undefined
+}
+
+export const getBoardDetails = createAsyncThunk('board/getBoardDetails', async (boardId: string, thunkAPI) => {
+  const response = await http.get<BoardResType>(`${envConfig.baseUrl}/boards/${boardId}`, { signal: thunkAPI.signal })
+  return response.data
+})
+
+export const boardSlice = createSlice({
+  name: 'board',
+  initialState,
+  reducers: {
+    updateActiveBoard: (state, action: PayloadAction<BoardResType['result'] | null>) => {
+      const board = action.payload
+      state.activeBoard = board
+    }
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(getBoardDetails.pending, (state, action) => {
+        if (state.loading === 'idle') {
+          state.loading = 'pending'
+          state.currentRequestId = action.meta.requestId
+        }
+      })
+      .addCase(getBoardDetails.fulfilled, (state, action) => {
+        const { requestId } = action.meta
+
+        if (state.loading === 'pending' && state.currentRequestId === requestId) {
+          state.loading = 'idle'
+
+          let board = action.payload.result
+
+          board.columns = mapOrder(board.columns, board.column_order_ids, '_id')
+
+          board.columns.forEach((column) => {
+            if (isEmpty(column.cards)) {
+              column.cards = [generatePlaceholderCard(column)]
+              column.card_order_ids = [generatePlaceholderCard(column)._id]
+            } else {
+              column.cards = mapOrder(column.cards, column.card_order_ids, '_id')
+            }
+          })
+
+          state.activeBoard = board
+
+          state.currentRequestId = undefined
+        }
+      })
+      .addCase(getBoardDetails.rejected, (state, action) => {
+        const { requestId } = action.meta
+
+        if (state.loading === 'pending' && state.currentRequestId === requestId) {
+          state.loading = 'idle'
+          state.currentRequestId = undefined
+        }
+      })
+  }
+})
+
+export const { updateActiveBoard } = boardSlice.actions
+
+const boardReducer = boardSlice.reducer
+
+export default boardReducer


### PR DESCRIPTION
Switch to using board slices for managing board state and implement `createAsyncThunk` for fetching board details from the API. This enhances state management and improves the handling of board-related data.