### PR TITLE
Implement change password functionality with validation and API integration

### DIFF
--- a/src/pages/Settings/components/SecurityTab/SecurityTab.tsx
+++ b/src/pages/Settings/components/SecurityTab/SecurityTab.tsx
@@ -1,3 +1,177 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { useForm } from 'react-hook-form'
+import { useChangePasswordMutation } from '~/queries/users'
+import { ChangePasswordBody, ChangePasswordBodyType } from '~/schemas/user.schema'
+import { useTheme } from '@mui/material/styles'
+import { useMediaQuery } from '@mui/material'
+import TextFieldInput from '~/components/Form/TextFieldInput'
+import FieldErrorAlert from '~/components/Form/FieldErrorAlert'
+import PasswordIcon from '@mui/icons-material/Password'
+import InputAdornment from '@mui/material/InputAdornment'
+import LockIcon from '@mui/icons-material/Lock'
+import LockResetIcon from '@mui/icons-material/LockReset'
+import Button from '@mui/material/Button'
+import { useConfirm } from 'material-ui-confirm'
+import LogoutIcon from '@mui/icons-material/Logout'
+import { useEffect } from 'react'
+import { isUnprocessableEntityError } from '~/utils/error-handlers'
+
 export default function SecurityTab() {
-  return <div>SecurityTab</div>
+  const theme = useTheme()
+  const isScreenAboveMobileScreen = useMediaQuery(theme.breakpoints.up(480))
+
+  const {
+    register,
+    setError,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<ChangePasswordBodyType>({
+    resolver: zodResolver(ChangePasswordBody),
+    defaultValues: { old_password: '', password: '', confirm_password: '' }
+  })
+
+  const [changePasswordMutation, { isError, error }] = useChangePasswordMutation()
+
+  const confirmChangePassword = useConfirm()
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      const { confirmed } = await confirmChangePassword({
+        title: (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <LogoutIcon sx={{ color: 'warning.dark' }} /> Change Password
+          </Box>
+        ),
+        description: 'You have to login again after successfully changing your password. Continue?',
+        confirmationText: 'Confirm',
+        cancellationText: 'Cancel'
+      })
+
+      if (confirmed) {
+        await changePasswordMutation(values)
+      }
+    } catch (error: any) {
+      console.log('Change password canceled or failed', error)
+    }
+  })
+
+  useEffect(() => {
+    if (isError && isUnprocessableEntityError<ChangePasswordBodyType>(error)) {
+      const formError = error.data.errors
+
+      if (formError) {
+        for (const [key, value] of Object.entries(formError)) {
+          setError(key as keyof ChangePasswordBodyType, {
+            type: value.type,
+            message: value.msg
+          })
+        }
+      }
+    }
+  }, [isError, error, setError])
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }}
+    >
+      <Box
+        sx={{
+          maxWidth: '1200px',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 3
+        }}
+      >
+        <Box>
+          <Typography variant='h5'>Security Dashboard</Typography>
+        </Box>
+        <form onSubmit={onSubmit}>
+          <Box
+            sx={{
+              width: isScreenAboveMobileScreen ? '400px' : '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2
+            }}
+          >
+            <Box>
+              <TextFieldInput
+                name='old_password'
+                register={register}
+                fullWidth
+                type='password'
+                label='Current Password'
+                error={!!errors['old_password']}
+                variant='outlined'
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position='start'>
+                      <PasswordIcon fontSize='small' />
+                    </InputAdornment>
+                  )
+                }}
+              />
+              <FieldErrorAlert errorMessage={errors.old_password?.message} />
+            </Box>
+
+            <Box>
+              <TextFieldInput
+                name='password'
+                register={register}
+                fullWidth
+                type='password'
+                label='New Password'
+                error={!!errors['password']}
+                variant='outlined'
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position='start'>
+                      <LockIcon fontSize='small' />
+                    </InputAdornment>
+                  )
+                }}
+              />
+              <FieldErrorAlert errorMessage={errors.password?.message} />
+            </Box>
+
+            <Box>
+              <TextFieldInput
+                name='confirm_password'
+                register={register}
+                fullWidth
+                type='password'
+                label='New Password Confirmation'
+                error={!!errors['confirm_password']}
+                variant='outlined'
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position='start'>
+                      <LockResetIcon fontSize='small' />
+                    </InputAdornment>
+                  )
+                }}
+              />
+              <FieldErrorAlert errorMessage={errors.confirm_password?.message} />
+            </Box>
+
+            <Box>
+              <Button className='interceptor-loading' type='submit' variant='contained' color='primary' fullWidth>
+                Update
+              </Button>
+            </Box>
+          </Box>
+        </form>
+      </Box>
+    </Box>
+  )
 }

--- a/src/queries/users.ts
+++ b/src/queries/users.ts
@@ -1,7 +1,8 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
 import { toast } from 'react-toastify'
 import axiosBaseQuery from '~/lib/redux/helpers'
-import { UpdateMeBodyType, UserResType } from '~/schemas/user.schema'
+import { authApi } from '~/queries/auth'
+import { ChangePasswordBodyType, ChangePasswordResType, UpdateMeBodyType, UserResType } from '~/schemas/user.schema'
 import { setProfile } from '~/store/slices/auth.slice'
 
 const USERS_API_URL = '/users' as const
@@ -18,6 +19,7 @@ export const userApi = createApi({
       query: () => ({ url: `${USERS_API_URL}/me`, method: 'GET' }),
       providesTags: (result) => (result ? [{ type: 'User', id: result.result._id }] : tagTypes)
     }),
+
     updateMe: build.mutation<UserResType, UpdateMeBodyType>({
       query: (body) => ({ url: `${USERS_API_URL}/me`, method: 'PATCH', data: body }),
       async onQueryStarted(_args, { dispatch, queryFulfilled }) {
@@ -33,11 +35,25 @@ export const userApi = createApi({
         }
       },
       invalidatesTags: (result) => (result ? [{ type: 'User', id: result.result._id }] : tagTypes)
+    }),
+
+    changePassword: build.mutation<ChangePasswordResType, ChangePasswordBodyType>({
+      query: (body) => ({ url: `${USERS_API_URL}/change-password`, method: 'PUT', data: body }),
+      async onQueryStarted(_args, { dispatch, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled
+          toast.success(data.message)
+
+          dispatch(authApi.endpoints.logout.initiate(undefined))
+        } catch (error: any) {
+          console.error(error)
+        }
+      }
     })
   })
 })
 
-export const { useGetMeQuery, useUpdateMeMutation } = userApi
+export const { useGetMeQuery, useUpdateMeMutation, useChangePasswordMutation } = userApi
 
 const userApiReducer = userApi.reducer
 

--- a/src/schemas/user.schema.ts
+++ b/src/schemas/user.schema.ts
@@ -37,3 +37,45 @@ export const UpdateMeBody = z.object({
 })
 
 export type UpdateMeBodyType = z.TypeOf<typeof UpdateMeBody>
+
+export const ChangePasswordBody = z
+  .object({
+    old_password: z
+      .string()
+      .min(6, 'Old password must be at least 6 characters')
+      .max(50, 'Old password must be at most 50 characters')
+      .regex(/[a-z]/, { message: 'Old password must contain at least 1 lowercase letter' })
+      .regex(/[A-Z]/, { message: 'Old password must contain at least 1 uppercase letter' })
+      .regex(/[0-9]/, { message: 'Old password must contain at least 1 number' })
+      .regex(/[^a-zA-Z0-9]/, { message: 'Old password must contain at least 1 symbol' }),
+    password: z
+      .string()
+      .min(6, 'New password must be at least 6 characters')
+      .max(50, 'New password must be at most 50 characters')
+      .regex(/[a-z]/, { message: 'New password must contain at least 1 lowercase letter' })
+      .regex(/[A-Z]/, { message: 'New password must contain at least 1 uppercase letter' })
+      .regex(/[0-9]/, { message: 'New password must contain at least 1 number' })
+      .regex(/[^a-zA-Z0-9]/, { message: 'New password must contain at least 1 symbol' }),
+    confirm_password: z
+      .string()
+      .min(6, 'Confirm password must be at least 6 characters')
+      .max(50, 'Confirm password must be at most 50 characters')
+  })
+  .strict()
+  .superRefine(({ confirm_password, password }, ctx) => {
+    if (confirm_password !== password) {
+      ctx.addIssue({
+        code: 'custom',
+        message: "New passwords don't match",
+        path: ['confirm_password']
+      })
+    }
+  })
+
+export type ChangePasswordBodyType = z.TypeOf<typeof ChangePasswordBody>
+
+export const ChangePasswordRes = z.object({
+  message: z.string()
+})
+
+export type ChangePasswordResType = z.TypeOf<typeof ChangePasswordRes>


### PR DESCRIPTION
Introduce a new feature that allows users to change their passwords with validation checks and integrates with the API for password updates. The implementation includes user feedback for errors and confirmations.