### PR TITLE
Integrate Unsplash API for Board Cover Photo Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "material-ui-confirm": "^4.0.0",
+        "mui-color-input": "^1.1.1",
         "randomcolor": "^0.6.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -319,6 +320,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -5509,6 +5519,28 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/mui-color-input": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mui-color-input/-/mui-color-input-1.1.1.tgz",
+      "integrity": "sha512-n0nH0we+URAzVF28W48LusaNZsGpo9+eUasqX21TuLI8Ogplyg/d4qJBBzXL2iiOwdprIOeIODPGqw2NFxWVNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.6.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^5.0.0",
+        "@types/react": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
@@ -7164,20 +7196,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
-    },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
     "material-ui-confirm": "^4.0.0",
+    "mui-color-input": "^1.1.1",
     "randomcolor": "^0.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -4,7 +4,6 @@ const Main = styled('main', {
   shouldForwardProp: (prop) => prop !== 'workspaceDrawerOpen' && prop !== 'boardDrawerOpen'
 })<{ workspaceDrawerOpen?: boolean; boardDrawerOpen?: boolean }>(({ theme, workspaceDrawerOpen, boardDrawerOpen }) => ({
   flexGrow: 1,
-  // padding: theme.spacing(3),
 
   transition: theme.transitions.create('margin', {
     easing: theme.transitions.easing.sharp,

--- a/src/components/Modal/ActiveCard/ActiveCard.tsx
+++ b/src/components/Modal/ActiveCard/ActiveCard.tsx
@@ -107,16 +107,17 @@ export default function ActiveCard() {
 
     formData.append('image', file as File)
 
-    const uploadImageRes = await uploadImageMutation(formData).unwrap()
+    const uploadImageRes = await toast.promise(uploadImageMutation(formData).unwrap(), {
+      pending: 'Uploading...',
+      success: 'Upload successfully!',
+      error: 'Upload failed!'
+    })
     const imageUrl = uploadImageRes.result[0].url
 
-    toast.promise(
-      handleUpdateActiveCard({ cover_photo: imageUrl }).finally(() => {
-        // Clear the input value after upload
-        event.target.value = ''
-      }),
-      { pending: 'Uploading...', success: 'Upload successfully!' }
-    )
+    handleUpdateActiveCard({ cover_photo: imageUrl }).finally(() => {
+      // Clear the input value after upload
+      event.target.value = ''
+    })
   }
 
   const onAddCardComment = async (comment: CommentType) => {
@@ -260,7 +261,7 @@ export default function ActiveCard() {
               <SidebarItem className='active' component='label'>
                 <ImageOutlinedIcon fontSize='small' />
                 Cover
-                <VisuallyHiddenInput type='file' onChange={onUploadCardCoverPhoto} />
+                <VisuallyHiddenInput type='file' accept='image/*' onChange={onUploadCardCoverPhoto} />
               </SidebarItem>
 
               <SidebarItem>

--- a/src/components/NavBar/MenuDrawer/MenuDrawer.tsx
+++ b/src/components/NavBar/MenuDrawer/MenuDrawer.tsx
@@ -35,30 +35,29 @@ interface MenuDrawerProps {
 }
 
 export default function MenuDrawer({ onToggleDrawer }: MenuDrawerProps) {
-  // Separate state for each section
   const [workspacesOpen, setWorkspacesOpen] = useState(false)
   const [recentOpen, setRecentOpen] = useState(false)
   const [starredOpen, setStarredOpen] = useState(false)
   const [templatesOpen, setTemplatesOpen] = useState(false)
 
-  // Handle click for each section
   const handleWorkspacesClick = (event: React.MouseEvent) => {
-    event.stopPropagation() // Prevent drawer from closing
+    // Prevent drawer from closing
+    event.stopPropagation()
     setWorkspacesOpen(!workspacesOpen)
   }
 
   const handleRecentClick = (event: React.MouseEvent) => {
-    event.stopPropagation() // Prevent drawer from closing
+    event.stopPropagation()
     setRecentOpen(!recentOpen)
   }
 
   const handleStarredClick = (event: React.MouseEvent) => {
-    event.stopPropagation() // Prevent drawer from closing
+    event.stopPropagation()
     setStarredOpen(!starredOpen)
   }
 
   const handleTemplatesClick = (event: React.MouseEvent) => {
-    event.stopPropagation() // Prevent drawer from closing
+    event.stopPropagation()
     setTemplatesOpen(!templatesOpen)
   }
 

--- a/src/lib/redux/store.ts
+++ b/src/lib/redux/store.ts
@@ -42,11 +42,6 @@ export const store = configureStore({
 
 export const persistor = persistStore(store)
 
-// export const makeStore = () => store
-
-// Infer the type of makeStore
-// export type AppStore = ReturnType<typeof makeStore>
-
 // Infer the type of the store
 export type AppStore = typeof store
 

--- a/src/pages/404/NotFound/NotFound.tsx
+++ b/src/pages/404/NotFound/NotFound.tsx
@@ -24,7 +24,6 @@ export default function NotFound() {
           backgroundSize: 'contain',
           backgroundRepeat: 'repeat',
           backgroundPosition: 'center',
-          // boxShadow: 'inset 0 0 0 2000px rgba(0, 0, 0, 0.2)',
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',

--- a/src/pages/Boards/BoardDetails/BoardDetails.tsx
+++ b/src/pages/Boards/BoardDetails/BoardDetails.tsx
@@ -125,9 +125,10 @@ export default function BoardDetails() {
       <Box
         sx={{
           position: 'relative',
-          backgroundImage: 'url(https://images6.alphacoders.com/138/thumbbig-1386838.webp)',
+          backgroundImage: activeBoard.cover_photo ? `url(${activeBoard.cover_photo})` : 'none',
           backgroundSize: 'cover',
-          backgroundPosition: 'center'
+          backgroundPosition: 'center',
+          bgcolor: isDarkMode ? 'grey.900' : 'primary.main'
         }}
       >
         {isDarkMode && (

--- a/src/pages/Boards/BoardDetails/components/BoardDrawer/BoardDrawer.tsx
+++ b/src/pages/Boards/BoardDetails/components/BoardDrawer/BoardDrawer.tsx
@@ -16,6 +16,8 @@ import DashboardIcon from '@mui/icons-material/Dashboard'
 import GroupsIcon from '@mui/icons-material/Groups'
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder'
 import DeleteIcon from '@mui/icons-material/Delete'
+import { useState } from 'react'
+import ChangeBackgroundDrawer from '~/pages/Boards/BoardDetails/components/ChangeBackgroundDrawer'
 
 interface BoardDrawerProps {
   open: boolean
@@ -25,68 +27,78 @@ interface BoardDrawerProps {
 export default function BoardDrawer({ open, onOpen }: BoardDrawerProps) {
   const theme = useTheme()
 
+  const [changeBackgroundDrawer, setChangeBackgroundDrawer] = useState(false)
+
+  const onOpenChangeBackgroundDrawer = (open: boolean) => {
+    setChangeBackgroundDrawer(open)
+  }
+
   return (
-    <Drawer
-      sx={{
-        width: theme.trellone.boardDrawerWidth,
-        flexShrink: 0,
-        '& .MuiDrawer-paper': {
+    <>
+      <Drawer
+        sx={{
           width: theme.trellone.boardDrawerWidth,
-          boxSizing: 'border-box',
-          top: 'auto',
-          height: `calc(100vh - ${theme.trellone.navBarHeight})`
-        }
-      }}
-      variant='persistent'
-      anchor='right'
-      open={open}
-    >
-      <DrawerHeader sx={{ justifyContent: 'space-between', minHeight: `${theme.trellone.navBarHeight}px!important` }}>
-        <IconButton color='inherit' onClick={() => onOpen(false)}>
-          {theme.direction === 'rtl' ? <ChevronLeftIcon /> : <ChevronRightIcon />}
-        </IconButton>
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: theme.trellone.boardDrawerWidth,
+            boxSizing: 'border-box',
+            top: 'auto',
+            height: `calc(100vh - ${theme.trellone.navBarHeight})`
+          }
+        }}
+        variant='persistent'
+        anchor='right'
+        open={open}
+      >
+        <DrawerHeader sx={{ justifyContent: 'space-between', minHeight: `${theme.trellone.navBarHeight}px!important` }}>
+          <IconButton color='inherit' onClick={() => onOpen(false)}>
+            {theme.direction === 'rtl' ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+          </IconButton>
 
-        <Typography variant='subtitle1'>Menu</Typography>
-        <Box sx={{ width: 40, height: 40 }} />
-      </DrawerHeader>
-      <Divider />
-      <List>
-        <ListItem disablePadding>
-          <ListItemButton>
-            <ListItemIcon>
-              <DashboardIcon />
-            </ListItemIcon>
-            <ListItemText secondary='About this board' />
-          </ListItemButton>
-        </ListItem>
+          <Typography variant='subtitle1'>Menu</Typography>
+          <Box sx={{ width: 40, height: 40 }} />
+        </DrawerHeader>
+        <Divider />
+        <List>
+          <ListItem disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                <DashboardIcon />
+              </ListItemIcon>
+              <ListItemText secondary='About this board' />
+            </ListItemButton>
+          </ListItem>
 
-        <ListItem disablePadding>
-          <ListItemButton>
-            <ListItemIcon>
-              <FavoriteBorderIcon />
-            </ListItemIcon>
-            <ListItemText secondary='Change background' />
-          </ListItemButton>
-        </ListItem>
+          <ListItem disablePadding>
+            <ListItemButton onClick={() => onOpenChangeBackgroundDrawer(true)}>
+              <ListItemIcon>
+                <FavoriteBorderIcon />
+              </ListItemIcon>
+              <ListItemText secondary='Change background' />
+            </ListItemButton>
+          </ListItem>
 
-        <ListItem disablePadding>
-          <ListItemButton>
-            <ListItemIcon>
-              <GroupsIcon />
-            </ListItemIcon>
-            <ListItemText secondary='Members (8)' />
-          </ListItemButton>
-        </ListItem>
+          <ChangeBackgroundDrawer open={changeBackgroundDrawer} onOpen={onOpenChangeBackgroundDrawer} />
 
-        <ListItem disablePadding>
-          <ListItemButton>
-            <ListItemIcon>
-              <DeleteIcon />
-            </ListItemIcon>
-            <ListItemText secondary='Delete this board' />
-          </ListItemButton>
-        </ListItem>
-      </List>
-    </Drawer>
+          <ListItem disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                <GroupsIcon />
+              </ListItemIcon>
+              <ListItemText secondary='Members (8)' />
+            </ListItemButton>
+          </ListItem>
+
+          <ListItem disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                <DeleteIcon />
+              </ListItemIcon>
+              <ListItemText secondary='Delete this board' />
+            </ListItemButton>
+          </ListItem>
+        </List>
+      </Drawer>
+    </>
   )
 }

--- a/src/pages/Boards/BoardDetails/components/ChangeBackgroundDrawer/ChangeBackgroundDrawer.tsx
+++ b/src/pages/Boards/BoardDetails/components/ChangeBackgroundDrawer/ChangeBackgroundDrawer.tsx
@@ -1,0 +1,169 @@
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import { useTheme } from '@mui/material'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Container from '@mui/material/Container'
+import Divider from '@mui/material/Divider'
+import Drawer from '@mui/material/Drawer'
+import IconButton from '@mui/material/IconButton'
+import ImageList from '@mui/material/ImageList'
+import ImageListItem from '@mui/material/ImageListItem'
+import ListItem from '@mui/material/ListItem'
+import ListItemButton from '@mui/material/ListItemButton'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { useState } from 'react'
+import DrawerHeader from '~/components/DrawerHeader'
+import { useAppDispatch, useAppSelector } from '~/lib/redux/hooks'
+import { useUpdateBoardMutation } from '~/queries/boards'
+import { useGetUnsplashSearchPhotosQuery, useUploadImageMutation } from '~/queries/medias'
+import { updateActiveBoard } from '~/store/slices/board.slice'
+import AddIcon from '@mui/icons-material/Add'
+import ListItemIcon from '@mui/material/ListItemIcon'
+
+// @ts-expect-error - Missing type definitions for mui-color-input package
+import { MuiColorInput, MuiColorInputValue } from 'mui-color-input'
+import VisuallyHiddenInput from '~/components/Form/VisuallyHiddenInput'
+import { config } from '~/constants/config'
+import { toast } from 'react-toastify'
+
+interface ChangeBackgroundDrawerProps {
+  open: boolean
+  onOpen: (open: boolean) => void
+}
+
+export default function ChangeBackgroundDrawer({ open, onOpen }: ChangeBackgroundDrawerProps) {
+  const theme = useTheme()
+
+  const [value, setValue] = useState<MuiColorInputValue>('')
+
+  const handleColorInputChange = (newValue: string) => {
+    setValue(newValue)
+  }
+
+  const dispatch = useAppDispatch()
+  const { activeBoard } = useAppSelector((state) => state.board)
+
+  const { data: searchPhotosData } = useGetUnsplashSearchPhotosQuery('Wallpapers')
+  const searchPhotos = searchPhotosData?.result || []
+
+  const [updateBoardMutation] = useUpdateBoardMutation()
+  const [uploadImageMutation] = useUploadImageMutation()
+
+  const handleUpdateBoardCoverPhoto = async (cover_photo: string) => {
+    const newActiveBoard = { ...activeBoard! }
+    newActiveBoard.cover_photo = cover_photo
+
+    dispatch(updateActiveBoard(newActiveBoard))
+
+    updateBoardMutation({
+      id: newActiveBoard._id,
+      body: { cover_photo: newActiveBoard.cover_photo }
+    })
+  }
+
+  const handleUploadBoardCoverPhoto = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+
+    if (file && (file.size >= config.maxSizeUploadAvatar || !file.type.includes('image'))) {
+      toast.error('Maximum file size is 3MB and file type must be an image.', { position: 'top-center' })
+      return
+    }
+
+    const formData = new FormData()
+
+    formData.append('image', file as File)
+
+    const uploadImageRes = await toast.promise(uploadImageMutation(formData).unwrap(), {
+      pending: 'Uploading...',
+      success: 'Upload successfully!',
+      error: 'Upload failed!'
+    })
+
+    const imageUrl = uploadImageRes.result[0].url
+
+    handleUpdateBoardCoverPhoto(imageUrl)
+  }
+
+  return (
+    <Drawer
+      sx={{
+        width: theme.trellone.boardDrawerWidth,
+        flexShrink: 0,
+        '& .MuiDrawer-paper': { top: `${theme.trellone.navBarHeight}` }
+      }}
+      variant='persistent'
+      anchor='right'
+      open={open}
+    >
+      <DrawerHeader sx={{ justifyContent: 'space-between', minHeight: `${theme.trellone.navBarHeight}px!important` }}>
+        <IconButton color='inherit' onClick={() => onOpen(false)}>
+          {theme.direction === 'rtl' ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+        </IconButton>
+
+        <Typography variant='subtitle1'>Background Cover</Typography>
+
+        <Box sx={{ width: 40, height: 40 }} />
+      </DrawerHeader>
+
+      <Divider />
+
+      <Container fixed sx={{ py: 1 }}>
+        <Stack gap={1.5}>
+          <Button variant='contained' size='small' color='secondary' fullWidth>
+            Remove Cover
+          </Button>
+
+          <Box>
+            <Typography variant='caption' fontWeight={500}>
+              Colors
+            </Typography>
+            <MuiColorInput size='small' fullWidth value={value} onChange={handleColorInputChange} format='hex8' />{' '}
+          </Box>
+
+          <Box>
+            <Typography variant='caption' fontWeight={500}>
+              Options
+            </Typography>
+
+            <ImageList variant='standard' cols={3} gap={2}>
+              <ListItem disablePadding>
+                <ListItemButton
+                  sx={{
+                    p: 0,
+                    width: '100%',
+                    height: '100%',
+                    justifyContent: 'center'
+                  }}
+                  component='label'
+                >
+                  <ListItemIcon>
+                    <AddIcon />
+                  </ListItemIcon>
+                  <VisuallyHiddenInput type='file' accept='image/*' onChange={handleUploadBoardCoverPhoto} />
+                </ListItemButton>
+              </ListItem>
+
+              {searchPhotos?.length > 0 &&
+                searchPhotos.map((photo) => {
+                  const { id, urls, description } = photo
+
+                  return (
+                    <ImageListItem
+                      onClick={() => handleUpdateBoardCoverPhoto(urls.regular)}
+                      sx={{ p: 0 }}
+                      component={ListItemButton}
+                      key={id}
+                    >
+                      <img loading='lazy' src={urls?.thumb} alt={description ?? ''} />
+                    </ImageListItem>
+                  )
+                })}
+            </ImageList>
+          </Box>
+        </Stack>
+      </Container>
+    </Drawer>
+  )
+}

--- a/src/pages/Boards/BoardDetails/components/ChangeBackgroundDrawer/index.ts
+++ b/src/pages/Boards/BoardDetails/components/ChangeBackgroundDrawer/index.ts
@@ -1,0 +1,3 @@
+import ChangeBackgroundDrawer from '~/pages/Boards/BoardDetails/components/ChangeBackgroundDrawer/ChangeBackgroundDrawer'
+
+export default ChangeBackgroundDrawer

--- a/src/pages/Boards/BoardDetails/components/WorkspaceDrawer/WorkspaceDrawer.tsx
+++ b/src/pages/Boards/BoardDetails/components/WorkspaceDrawer/WorkspaceDrawer.tsx
@@ -107,58 +107,17 @@ export default function WorkspaceDrawer({ open, onOpen, boardId }: WorkspaceDraw
           width: theme.trellone.workspaceDrawerWidth,
           boxSizing: 'border-box',
           top: 'auto',
-          height: `calc(100% - ${theme.trellone.navBarHeight})`
+          height: `calc(100vh - ${theme.trellone.navBarHeight})`
         }
       }}
       variant='persistent'
       anchor='left'
       open={open}
     >
-      <DrawerHeader sx={{ justifyContent: 'space-between', minHeight: '49px!important' }}>
-        <Stack ml={1} gap={1} alignItems='center' direction='row'>
-          <WorkspaceAvatar workspaceName='My Project' avatarSize={{ width: 30, height: 30 }} />
-          <Typography variant='subtitle1'>My Project</Typography>
-        </Stack>
-        <IconButton color='inherit' onClick={() => onOpen(false)}>
-          {theme.direction === 'ltr' ? <ChevronLeftIcon /> : <ChevronRightIcon />}
-        </IconButton>
-      </DrawerHeader>
-      <Divider />
-      <List>
-        <ListItem disablePadding>
-          <ListItemButton onClick={() => {}}>
-            <ListItemIcon>
-              <DashboardIcon />
-            </ListItemIcon>
-            <ListItemText secondary='Boards' />
-          </ListItemButton>
-        </ListItem>
-        <ListItem disablePadding>
-          <ListItemButton onClick={() => {}}>
-            <ListItemIcon>
-              <GroupsIcon />
-            </ListItemIcon>
-            <ListItemText secondary='Members' />
-          </ListItemButton>
-        </ListItem>
-        <ListItem disablePadding>
-          <ListItemButton onClick={() => {}}>
-            <ListItemIcon>
-              <SettingsIcon />
-            </ListItemIcon>
-            <ListItemText secondary='Workspace Settings' />
-          </ListItemButton>
-        </ListItem>
-      </List>
-      <Divider />
-      <Typography variant='subtitle1' p={2} pb={1}>
-        Your Boards
-      </Typography>
       <Box
         ref={scrollableRef}
         sx={{
-          height: 'calc(100vh - 280px)',
-          overflowY: 'inherit',
+          overflowY: 'auto',
           '&::-webkit-scrollbar': { width: '8px' },
           '&::-webkit-scrollbar-thumb': {
             backgroundColor: isDarkMode ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.2)',
@@ -167,6 +126,46 @@ export default function WorkspaceDrawer({ open, onOpen, boardId }: WorkspaceDraw
         }}
         id='scrollableDiv'
       >
+        <DrawerHeader sx={{ justifyContent: 'space-between', minHeight: '49px!important' }}>
+          <Stack ml={1} gap={1} alignItems='center' direction='row'>
+            <WorkspaceAvatar workspaceName='My Project' avatarSize={{ width: 30, height: 30 }} />
+            <Typography variant='subtitle1'>My Project</Typography>
+          </Stack>
+          <IconButton color='inherit' onClick={() => onOpen(false)}>
+            {theme.direction === 'ltr' ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+          </IconButton>
+        </DrawerHeader>
+        <Divider />
+        <List>
+          <ListItem disablePadding>
+            <ListItemButton onClick={() => {}}>
+              <ListItemIcon>
+                <DashboardIcon />
+              </ListItemIcon>
+              <ListItemText secondary='Boards' />
+            </ListItemButton>
+          </ListItem>
+          <ListItem disablePadding>
+            <ListItemButton onClick={() => {}}>
+              <ListItemIcon>
+                <GroupsIcon />
+              </ListItemIcon>
+              <ListItemText secondary='Members' />
+            </ListItemButton>
+          </ListItem>
+          <ListItem disablePadding>
+            <ListItemButton onClick={() => {}}>
+              <ListItemIcon>
+                <SettingsIcon />
+              </ListItemIcon>
+              <ListItemText secondary='Workspace Settings' />
+            </ListItemButton>
+          </ListItem>
+        </List>
+        <Divider />
+        <Typography variant='subtitle1' p={2} pb={1}>
+          Your Boards
+        </Typography>
         <InfiniteScroll
           dataLength={boards.length}
           next={getMoreBoards}

--- a/src/pages/Workspaces/components/NavigationMenu/NavigationMenu.tsx
+++ b/src/pages/Workspaces/components/NavigationMenu/NavigationMenu.tsx
@@ -50,8 +50,6 @@ export default function NavigationMenu() {
   return (
     <List
       sx={{
-        pt: 5,
-        // display: { xs: 'none', sm: 'block' },
         width: '100%',
         maxWidth: { xs: '100%', sm: 250 },
         bgcolor: 'background.paper'

--- a/src/pages/Workspaces/layouts/HomeLayout/HomeLayout.tsx
+++ b/src/pages/Workspaces/layouts/HomeLayout/HomeLayout.tsx
@@ -15,18 +15,9 @@ export default function HomeLayout() {
     <Container disableGutters maxWidth={false}>
       <NavBar />
       <Container maxWidth='lg'>
-        <Stack direction={isMobileScreen ? 'column' : 'row'} useFlexGap={true} spacing={2}>
+        <Stack direction={isMobileScreen ? 'column' : 'row'} useFlexGap={true} spacing={2} py={{ xs: 3, sm: 5 }}>
           <NavigationMenu />
-          <Box
-            sx={{
-              py: 5,
-              pt: { xs: 0, sm: 5 },
-              overflowY: 'auto',
-              maxHeight: (theme) => `calc(100vh - ${theme.trellone.navBarHeight})`,
-              width: '100%',
-              maxWidth: { xs: '100%', sm: '70vw' }
-            }}
-          >
+          <Box sx={{ width: '100%', maxWidth: { xs: '100%', sm: '70vw' } }}>
             <Outlet />
           </Box>
         </Stack>

--- a/src/queries/medias.ts
+++ b/src/queries/medias.ts
@@ -1,6 +1,6 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
 import axiosBaseQuery from '~/lib/redux/helpers'
-import { UploadImageResType } from '~/schemas/media.schema'
+import { UnsplashSearchPhotosType, UploadImageResType } from '~/schemas/media.schema'
 
 const MEDIAS_API_URL = '/medias' as const
 
@@ -19,11 +19,19 @@ export const mediaApi = createApi({
         data: body,
         headers: { 'Content-Type': 'multipart/form-data' }
       })
+    }),
+
+    getUnsplashSearchPhotos: build.query<UnsplashSearchPhotosType, string>({
+      query: (params) => ({
+        url: `${MEDIAS_API_URL}/unsplash/search/get-photos`,
+        method: 'GET',
+        params: { query: params }
+      })
     })
   })
 })
 
-export const { useUploadImageMutation } = mediaApi
+export const { useUploadImageMutation, useGetUnsplashSearchPhotosQuery } = mediaApi
 
 const mediaApiReducer = mediaApi.reducer
 

--- a/src/schemas/board.schema.ts
+++ b/src/schemas/board.schema.ts
@@ -80,7 +80,8 @@ export const UpdateBoardBody = z.object({
     .enum(BoardTypeValues, { message: 'Type must be either public or private' })
     .default(BoardType.Public)
     .optional(),
-  column_order_ids: z.array(z.string()).optional()
+  column_order_ids: z.array(z.string()).optional(),
+  cover_photo: z.string().url().optional()
 })
 
 export type UpdateBoardBodyType = z.TypeOf<typeof UpdateBoardBody>

--- a/src/schemas/media.schema.ts
+++ b/src/schemas/media.schema.ts
@@ -11,4 +11,28 @@ export const UploadImageRes = z.object({
   message: z.string()
 })
 
+export const UnsplashImageUrlSchema = z.object({
+  url: z.string(),
+  full: z.string(),
+  regular: z.string(),
+  small: z.string(),
+  thumb: z.string(),
+  small_s3: z.string()
+})
+
+export type UnsplashImageUrlType = z.TypeOf<typeof UnsplashImageUrlSchema>
+
 export type UploadImageResType = z.TypeOf<typeof UploadImageRes>
+
+export const UnsplashSearchPhotos = z.object({
+  result: z.array(
+    z.object({
+      id: z.string(),
+      urls: UnsplashImageUrlSchema,
+      description: z.string()
+    })
+  ),
+  message: z.string()
+})
+
+export type UnsplashSearchPhotosType = z.TypeOf<typeof UnsplashSearchPhotos>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,7 +3,6 @@ import { experimental_extendTheme as extendTheme } from '@mui/material/styles'
 
 declare module '@mui/material/styles' {
   interface Theme {
-    // Add your custom properties here
     trellone: {
       navBarHeight: string
       workspaceDrawerWidth: string
@@ -15,9 +14,7 @@ declare module '@mui/material/styles' {
       columnFooterHeight: string
     }
   }
-  // allow configuration using `createTheme`
   interface ThemeOptions {
-    // Add your custom properties here
     trellone: {
       navBarHeight: string
       workspaceDrawerWidth: string
@@ -42,7 +39,6 @@ const BOARD_CONTENT_HEIGHT = `calc(100vh - ${NAV_BAR_HEIGHT} - ${BOARD_BAR_HEIGH
 const COLUMN_HEADER_HEIGHT = '50px'
 const COLUMN_FOOTER_HEIGHT = '56px'
 
-// A custom theme for this app
 const theme = extendTheme({
   trellone: {
     navBarHeight: NAV_BAR_HEIGHT,


### PR DESCRIPTION
Implement functionality to search and update board cover photos using the Unsplash API. This includes adding necessary schemas and API calls to fetch images, as well as updating the board details to reflect the selected cover photo.