### PR TITLE
Correct capitalization in .gitignore comment for visualization section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@ dist-ssr
 # md
 /mdx
 
-# visualize
+# Visualize
 stats.html


### PR DESCRIPTION
Update the comment in the .gitignore file to use consistent capitalization for the visualization section.