### PR TITLE
Reset form on attachment popover close

### DIFF
--- a/src/components/Modal/ActiveCard/AttachmentPopover/AttachmentPopover.tsx
+++ b/src/components/Modal/ActiveCard/AttachmentPopover/AttachmentPopover.tsx
@@ -39,6 +39,7 @@ const AttachmentPopover = forwardRef<HTMLButtonElement, AttachmentPopoverProps>(
       setAnchorPopoverElement(event.currentTarget)
     } else {
       setAnchorPopoverElement(null)
+      onReset()
     }
   }
 


### PR DESCRIPTION
Closing the attachment popover now resets the form, improving user experience by clearing any input when the popover is dismissed.